### PR TITLE
Monthly and auto backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ the command will create a new dirty bitmap and backup the virtual machines
 disks to ```/tmp/backup/<disk-id>/FULL-<timestamp>```. It ensures
 consistency by creating the bitmap and backup within one QMP transaction.
 
-See the following discussion on the qmeu-block mailinglist regarding
+See the following discussion on the qemu-block mailinglist regarding
 this topic:
 
  https://lists.nongnu.org/archive/html/qemu-block/2016-11/msg00682.html
@@ -59,6 +59,22 @@ the changed delta since your last full (or inc) backup will be dumped to
 ```/tmp/backup/<disk-id>INC-<timestamp>```, the dirty-bitmap is automatically
 cleared after this and you can continue creating further incremental backups by
 re-issuing the command likewise.
+
+There is also the `auto` backup level which combines the `full` and `inc` backup levels. If there's no existing bitmap for the VM, `full` will run. If a bitmap exists, `inc` will be used.
+
+Monthly Backups
+-----------------
+Using the `--monthly` flag with the `backup` command, backups will be placed in monthly folders in a YYYY-MM format.
+The above combined with the `auto` backup level, backups will be created in monthly backup chains.
+
+With a VM named *myfirstvm* and the date being 2021-11, the following command: 
+
+```/qmpbackup --socket /path/socket backup --level auto --monthly --target /tmp/backup``` 
+
+will place backups in the following backup path: `/tmp/backup/myfirstvm/2021-11/`
+
+When the date changes to 2021-12 and qmpbackup is run, backups will be placed in `/tmp/backup/myfirstvm/2021-12/` and a new full backup will be created.
+
 
 Filesystem Quisce
 -----------------

--- a/qmpbackup
+++ b/qmpbackup
@@ -41,7 +41,7 @@ parser_backup.add_argument(
     "--level", choices=["full", "inc", "auto"], type=str, help="backup level", required=True
 )
 parser_backup.add_argument(
-    "--monthly", action="store_true", help="monthly backup directories (in format YYYY-MM) and monthly chains. Note that this will clean existent bitmaps every month.", required=False
+    "--monthly", action="store_true", help="monthly backup directories (in format YYYY-MM). If combined with backup level 'auto' this will create monthly backup chains.", required=False
 )
 parser_backup.add_argument(
     "--quisce",

--- a/qmpbackup
+++ b/qmpbackup
@@ -14,6 +14,7 @@ import sys
 import argparse
 import string
 from time import sleep, time
+from datetime import datetime
 
 from libqmpbackup.qmpcommon import QmpCommon
 from libqmpbackup.qaclient import QemuGuestAgentClient
@@ -37,7 +38,10 @@ subparsers = parser.add_subparsers(help="sub-command help")
 parser_backup = subparsers.add_parser("backup", help="backup")
 parser_backup.set_defaults(which="backup")
 parser_backup.add_argument(
-    "--level", choices=["full", "inc"], type=str, help="backup level", required=True
+    "--level", choices=["full", "inc", "auto"], type=str, help="backup level", required=True
+)
+parser_backup.add_argument(
+    "--monthly", action="store_true", help="monthly backup directories (in format YYYY-MM) and monthly chains. Note that this will clean existent bitmaps every month.", required=False
 )
 parser_backup.add_argument(
     "--quisce",
@@ -75,6 +79,10 @@ qmp = QmpCommon(log, argv.socket)
 vminfo = VMInfo()
 
 log.info("Version: %s", version._version_)
+
+""" flags """
+newmonthlybackup = False
+bitmapjustcleaned = False
 
 """ Get all block devices for VM which are format qcow """
 try:
@@ -129,19 +137,23 @@ if action == "backup":
 
     if vm_name:
         backupdir = "%s/%s" % (argv.target, vm_name)
-        if not os.path.exists(backupdir):
-            os.mkdir(backupdir)
     else:
         backupdir = argv.target
+
+    if argv.monthly:
+        backupdir += "/%s" % (datetime.today().strftime('%Y-%m'))
 
     timestamp = int(time())
     if not os.path.isfile(backupdir):
         if not os.path.exists(backupdir):
             try:
-                os.mkdir(backupdir)
+                os.makedirs(backupdir, exist_ok=True)
             except Exception as e:
                 log.error("Unable to create target dir: %s", e)
                 sys.exit(1)
+            if argv.monthly:
+                log.info("New monthly directory created")
+                newmonthlybackup = True
         log.info("Backup target directory: %s" % backupdir)
     else:
         log.error("Backup target must be directory.")
@@ -172,7 +184,7 @@ if action == "backup":
                 )
                 sys.exit(1)
 
-        targetdir = "%s/%s/" % (backupdir, device.node)
+        targetdir = "%s/%s" % (backupdir, device.node)
         if not os.path.exists(targetdir):
             os.mkdir(targetdir)
 
@@ -204,6 +216,36 @@ if action == "backup":
                     )
                 )
             )
+
+        if argv.level == "auto":
+            if device.has_bitmap == False or newmonthlybackup == True: # Check if there's a FULL backup in the folder instead?
+                target = "%s/FULL-%s" % (targetdir, timestamp)
+                log.info('FULL Backup operation: "%s"' % target)
+                print(
+                    common.json_pp(
+                        qmp.do_full_backup_with_bitmap(
+                            device.has_bitmap,
+                            bitmap,
+                            device=device.node,
+                            target=target,
+                            sync="full",
+                        )
+                    )
+                )
+            else:
+                target = "%s/INC-%s" % (targetdir, timestamp)
+                log.info('INC Backup operation: "%s"' % target)
+                print(
+                    common.json_pp(
+                        qmp.do_qmp_backup(
+                            device=device.node,
+                            bitmap=bitmap,
+                            target=target,
+                            sync="incremental",
+                        )
+                    )
+                )
+
 
         if argv.agentsocket and argv.quisce and qga is not False:
             common.thaw(qga)


### PR DESCRIPTION
* Removed duplicate code for directory creation (See row 133 and 141 in original)
* Removed double / forward slashes in info log messages while doing backup operations.
* Monthly backup directories will separate VM backups per month. For example, with a VM named "myfirstvm" and the following command ```/qmpbackup --socket /path/socket backup --level auto --monthly --target /tmp/backup``` the backup path will look like this: `/tmp/backup/myfirstvm/2021-11/`
* Add `auto` backup level - Will use `full` if there are no bitmaps on the VM and `inc` if there is one. Combined with --monthly this will restart the backup chain every month.

Thank you for a nice project! 🥳 